### PR TITLE
Feature: Semantic search that helps users search based on meaning using AI

### DIFF
--- a/Sources/SearchMind/Internal/Models/EmbeddingRequest.swift
+++ b/Sources/SearchMind/Internal/Models/EmbeddingRequest.swift
@@ -1,0 +1,4 @@
+struct EmbeddingRequest: Codable {
+    let model: String
+    let input: [String]
+}

--- a/Sources/SearchMind/Internal/Models/EmbeddingResponse.swift
+++ b/Sources/SearchMind/Internal/Models/EmbeddingResponse.swift
@@ -1,0 +1,22 @@
+struct EmbeddingResponse: Codable {
+    let object: String
+    let data: [EmbeddingData]
+    let model: String
+    let usage: Usage
+}
+
+struct EmbeddingData: Codable {
+    let object: String
+    let index: Int
+    let embedding: [Double]
+}
+
+struct Usage: Codable {
+    let promptTokens: Int
+    let totalTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case totalTokens = "total_tokens"
+    }
+}

--- a/Sources/SearchMind/SearchMind.swift
+++ b/Sources/SearchMind/SearchMind.swift
@@ -381,7 +381,33 @@ public struct SearchOptions: Sendable {
     /// - Note: This option only affects `.file` searches, not `.fileContents` searches.
     /// - Important: Fuzzy matching may be slower for large directory structures.
     public let fuzzyMatching: Bool
-    
+
+  /// Enables semantic search using a large language model.
+  ///
+  /// When `true`, `.fileContents` searches will be powered by GPT-based embeddings
+  /// that understand the **meaning** of the query and the content, rather than just
+  /// relying on exact or fuzzy text matches.
+  ///
+  /// This allows users to find relevant results based on intent and context. For example,
+  /// searching for `"authentication"` might match content discussing `"login systems"`
+  /// or `"OAuth flows"`, even if those exact words don’t appear in the text.
+  ///
+  /// - Important: Requires a valid OpenAI API key and network access.
+  /// - Note: This option only affects `.fileContents` searches.
+  /// - SeeAlso: `patternMatch` for syntax-based searching, and `fuzzyMatching` for typo tolerance.
+    public let semantic: Bool
+
+    /// Enables pattern-based search using regular expressions.
+    ///
+    /// When `true`, `.fileContents` searches will interpret the query as a
+    /// regular expression pattern (e.g., `"\bclass\b"`).
+    ///
+    /// This is useful for advanced filtering based on syntax or naming conventions.
+    ///
+    /// - Note: This option only affects `.fileContents` searches.
+    /// - Warning: Malformed regex patterns may cause errors or performance issues.
+    public let patternMatch: Bool
+
     /// The maximum number of results to return from a search
     ///
     /// Limits the number of results returned from a search operation.
@@ -440,6 +466,8 @@ public struct SearchOptions: Sendable {
     public init(
         caseSensitive: Bool = false,
         fuzzyMatching: Bool = true,
+        semantic: Bool = false,
+        patternMatch: Bool = false,
         maxResults: Int = 100,
         searchPaths: [URL]? = nil,
         fileExtensions: [String]? = nil,
@@ -447,6 +475,8 @@ public struct SearchOptions: Sendable {
     ) {
         self.caseSensitive = caseSensitive
         self.fuzzyMatching = fuzzyMatching
+        self.semantic = semantic
+        self.patternMatch = patternMatch
         self.maxResults = max(1, maxResults) // Ensure maxResults is at least 1
         self.searchPaths = searchPaths
         self.fileExtensions = fileExtensions

--- a/Tests/SearchMindTests/SearchMindTests.swift
+++ b/Tests/SearchMindTests/SearchMindTests.swift
@@ -60,10 +60,34 @@ final class SearchMindTests: XCTestCase {
         XCTAssertFalse(results.isEmpty, "Should find at least one file with fuzzy matching")
         XCTAssertTrue(results.contains { $0.path.contains("sample.txt") }, "Should find sample.txt with fuzzy matching")
     }
-    
+
+  /// Test Semantic Search using GPT Embeddings
+  func testSemanticSearch() async throws {
+      // Given: Define search options for semantic search
+      let options = SearchOptions(
+          semantic: true,
+          searchPaths: [temporaryDirectory]
+      )
+
+      // Sample query and expected result
+      let query = "search terms"
+      let expectedFile = "document.doc"
+
+      // When: Perform the search using the 'search' method of the SearchMind class
+      let results = try await search.search(query, type: .fileContents, options: options)
+
+      // Then: Assert that the search returns at least one result
+      XCTAssertFalse(results.isEmpty, "Should find results for semantic search")
+
+      // And: Assert that the expected file is found based on the semantic relevance
+      XCTAssertTrue(results.contains { $0.path.contains(expectedFile) }, "Should find the document.doc file based on semantic search")
+  }
+
+
     func testFileContentSearch() async throws {
         // Test file content search
         let options = SearchOptions(
+            patternMatch: true,
             searchPaths: [temporaryDirectory]
         )
         


### PR DESCRIPTION
## Summary
This PR introduces `GPTSemanticSearchAlgorithm`, **a semantic search capability**, into the SearchMind Swift package using the **GPT-based** semantic search algorithm. It adds a new option under `SearchOptions` to enable semantic search and integrates the necessary logic in the _algorithm selector_.

This feature allows developers to perform searches based on **meaning** rather than **keywords**, powered by an _external LLM_ (like OpenAI).

## Changes
- **Semantic Search Added**
   - Added a new boolean flag semantic in `SearchOptions`
   - Since `PatternMatchAlgorithm` was the only algorithm for `fileContents` search, it was true by default when it comes to searching for fileContents. Defined the `PatternMatchAlgorithm` to false, since we are adding another search algorithm that serves this purpose.
   - Updated `SearchAlgorithmSelector` to return `GPTSemanticSearchAlgorithm` when `.semantic` is enabled
   - Connected semantic search with API key lookup using `ProcessInfo.processInfo.environment`
       - Methods for securing `API KEYS` in development such as _.env, .xcconfig or Info.plist_ were not a great fit for us since they .env is not suited for the XCode environment and the other two methods were for app development.
       - The current method uses the processInfo to read the environment variable of the `OPENAI_API_KEY` earlier added
       - Before testing the swift package this environment variable should be added by the `export OPENAI_API_KEY="API_KEY"` command, otherwise the tests will fail due to the fact that the api key is missing.
    - Implemented error handling when API key is missing or decoding fails

- **Documentation (DocC)**
   - Documented **semantic** and **patternMatch** options in `SearchOptions`
   - Added performance and error-related notes for **patternMatch** (regex-based)

- **Tests**
   - Initial test case for `testSemanticSearch` added

## Next Steps
- Handling the api response errors in a better way by leveraging the current `SearchError.swift`.
- Expanding testSemanticSearch() further by adding more files in the test setup that help with a more in depth testing for the embedding and relevance scores.
- Improving the `cosineSimilarity` function using the swift-numerics package already available, if it benefits in performance terms. If not, we should avoid this because we add _unnecessary complexity_.
- Asking the developer for their api key in usage and take it as a **parameter** for the function
- Getting the **api key as a parameter** when the semantic search algorithm is selected. This data can be added as a _config_, which can be a struct that holds other data as well that can be used for _more customization_ of the experience.
   - This can be further scaled to the point that other _search algorithms_ can benefit from this too.
   - An idea that comes to my mind, which is not yet validated is to give the user the ability to select the algorithm by using an enum struct, and then getting a config struct which holds preferences like case _sensitivity, api key, api endpoint and etc._ By doing this we can benefit from the `Strategy Design Pattern`.
- Adding the possibility to use **different api endpoints**, other than OpenAI
   - For now we added _OpenAI endpoint_ which is the best and the most popular option among developers
   - The api endpoint `can be set alongside the api key` in the `config struct` mentioned earlier
- By following the rule of three, the `getFilesToSearch` function can be refactored into a single function that acts as a helper in the `Utils` folder that can be located in the internal folder.
- By following the `SRP principle`, algorithms can be break down into their own related file that follow a single responsibility.
- We considered enabling offline semantic embedding calculation by allowing `.coreml AI` models to be embedded within the project.
   - However, converted models (e.g., from OpenAI or Sentence Transformers) typically **consume unnecessarily large space (e.g., 64MB or more)**, which makes bundling them in the package unreasonable.
   - Instead, we can offer a hook for developers to provide their own Core ML model for embeddings if one already exists in their app. While this would **enable fully offline semantic search**, we consider it a non-priority luxury feature for now.
   - Supporting offline semantic search would be useful for **system-wide local searches**, but it becomes less relevant when the goal is to support semantic search over remote databases, which require internet connectivity.
   - That said, we recognize there are cases where **local databases (e.g., Core Data or SQLite)** are used, and may themselves be offline (disconnected from cloud sync, or fully local-first), so future support for offline embeddings and search could be revisited based on developer demand.


