### PR TITLE
feat: added the .database feature

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,24 +1,142 @@
 {
-  "originHash" : "226c925b25bd82078cc5fbdb5dbc394e22c5edee61e3de5f29c70d6ff00ffeaa",
-  "pins" : [
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
+  "object": {
+    "pins": [
+      {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+          "version": "1.2024011602.0"
+        }
+      },
+      {
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
+        "state": {
+          "branch": null,
+          "revision": "3b62f154d00019ae29a71e9738800bb6f18b236d",
+          "version": "10.19.2"
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+          "version": "10.29.0"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "fe727587518729046fc1465625b9afd80b5ab361",
+          "version": "10.28.0"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "a637d318ae7ae246b02d7305121275bc75ed5565",
+          "version": "9.4.0"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "57a1d307f42df690fdef2637f3e5b776da02aad6",
+          "version": "7.13.3"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+          "version": "1.62.2"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "a2ab612cb980066ee56d90d60d8462992c07f24b",
+          "version": "3.5.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
+          "version": "100.0.0"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+          "version": "1.22.5"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+          "version": "2.30910.0"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "state": {
+          "branch": null,
+          "revision": "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "102a647b573f60f73afdce5613a51d71349fe507",
+          "version": "1.30.0"
+        }
       }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
-        "version" : "1.0.3"
-      }
-    }
-  ],
-  "version" : 3
+    ]
+  },
+  "version": 1
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
 // swift-tools-version: 5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
@@ -10,7 +8,6 @@ let package = Package(
         .iOS(.v15),
     ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "SearchMind",
             targets: ["SearchMind"]
@@ -18,19 +15,23 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "SearchMind",
             dependencies: [
                 .product(name: "Algorithms", package: "swift-algorithms"),
+                .product(name: "FirebaseDatabase", package: "firebase-ios-sdk"),
             ]
+            // No resources here — your Firebase plist is for tests only
         ),
         .testTarget(
             name: "SearchMindTests",
-            dependencies: ["SearchMind"]
+            dependencies: ["SearchMind"],
+            resources: [
+                .process("Resources/GoogleService-Info.plist") // 🔥 Put the file here
+            ]
         ),
     ]
 )

--- a/Sources/SearchMind/Internal/Models/SearchableItem.swift
+++ b/Sources/SearchMind/Internal/Models/SearchableItem.swift
@@ -2,8 +2,7 @@ import Foundation
 
 struct SearchableItem: Sendable {
     let id: String
-    let title: String
-    let content: String?
+    let data: String
+    let path: String
     let metadata: [String: String]?
-  let path: String
 }

--- a/Sources/SearchMind/Internal/SearchEngine.swift
+++ b/Sources/SearchMind/Internal/SearchEngine.swift
@@ -1,4 +1,5 @@
 import Algorithms
+@preconcurrency import FirebaseDatabase
 import Foundation
 
 /// Protocol defining a search engine
@@ -66,6 +67,8 @@ final class SearchAlgorithmSelector: Sendable {
           return selectFileAlgorithm(options: options)
         case .fileContents:
           return selectFileContentsAlgorithm(options: options)
+        case .database:
+          return selectDatabaseAlgorithm(options: options)
       }
     }
 
@@ -85,7 +88,21 @@ final class SearchAlgorithmSelector: Sendable {
     }
 
     private func selectFileContentsAlgorithm(options: SearchOptions) -> SearchAlgorithm {
-      let provider = FileProvider()
+      let provider = FileContentsProvider()
+        if options.semantic {
+          return GPTSemanticSearchAlgorithm(provider: provider)
+        }
+        if options.patternMatch {
+          return PatternMatchAlgorithm(provider: provider)
+        }
+        if options.fuzzyMatching {
+          return FuzzyMatchAlgorithm(provider: provider)
+        }
+      return ExactMatchAlgorithm(provider: provider)
+    }
+
+    private func selectDatabaseAlgorithm(options: SearchOptions) -> SearchAlgorithm {
+      let provider = RealtimeDatabaseProvider()
         if options.semantic {
           return GPTSemanticSearchAlgorithm(provider: provider)
         }
@@ -114,17 +131,20 @@ final class FileProvider: Provider {
           let fileManager = FileManager.default
           var allFiles: [URL] = []
 
-          let searchPaths = options.searchPaths ?? [URL(fileURLWithPath: fileManager.currentDirectoryPath)]
+          guard let searchPaths = options.searchPaths else {
+            throw SearchError.searchPathUnavailable
+          }
+
           for path in searchPaths {
               var isDirectory: ObjCBool = false
 
-              guard fileManager.fileExists(atPath: path.path, isDirectory: &isDirectory) else {
-                  throw SearchError.invalidSearchPath(path.path)
+              guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory) else {
+                  throw SearchError.invalidSearchPath(path)
               }
 
               if isDirectory.boolValue {
                   let contents = try fileManager.contentsOfDirectory(
-                      at: path,
+                      at: URL(fileURLWithPath: path),
                       includingPropertiesForKeys: [.isRegularFileKey],
                       options: [.skipsHiddenFiles]
                   )
@@ -134,7 +154,7 @@ final class FileProvider: Provider {
                       }
                   }
               } else {
-                  allFiles.append(path)
+                allFiles.append(URL(fileURLWithPath: path))
               }
           }
 
@@ -142,17 +162,153 @@ final class FileProvider: Provider {
               allFiles = allFiles.filter { fileExtensions.contains($0.pathExtension) }
           }
 
-          return allFiles.map {
-            SearchableItem(id: UUID().uuidString, title: $0.lastPathComponent, content: nil, metadata: nil, path: $0.path)
-          }
+
+    var searchableItems: [SearchableItem] = []
+
+    for fileURL in allFiles {
+      let id = UUID().uuidString
+      let data = fileURL.lastPathComponent
+      let path = fileURL.path
+      let metadata = SearchSetup().createMetadata(
+            data: data,
+            path: fileURL.path,
+            providerType: .file
+        )
+      
+        let item = SearchableItem(
+          id: id,
+          data: data,
+          path: path,
+          metadata: metadata
+        )
+        searchableItems.append(item)
+    }
+
+    return searchableItems
       }
 }
+
+final class FileContentsProvider: Provider {
+    func fetchItems(for options: SearchOptions) async throws -> [SearchableItem] {
+        let fileManager = FileManager.default
+        var allFiles: [URL] = []
+
+        guard let searchPaths = options.searchPaths else {
+            throw SearchError.searchPathUnavailable
+        }
+
+        for path in searchPaths {
+            var isDirectory: ObjCBool = false
+
+            guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory) else {
+                throw SearchError.invalidSearchPath(path)
+            }
+
+            if isDirectory.boolValue {
+                let contents = try fileManager.contentsOfDirectory(
+                    at: URL(fileURLWithPath: path),
+                    includingPropertiesForKeys: [.isRegularFileKey],
+                    options: [.skipsHiddenFiles]
+                )
+                for url in contents {
+                    if let isRegular = try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isRegular {
+                        allFiles.append(url)
+                    }
+                }
+            } else {
+                allFiles.append(URL(fileURLWithPath: path))
+            }
+        }
+
+        if let fileExtensions = options.fileExtensions, !fileExtensions.isEmpty {
+            allFiles = allFiles.filter { fileExtensions.contains($0.pathExtension) }
+        }
+
+        var searchableItems: [SearchableItem] = []
+
+        for fileURL in allFiles {
+          let id = UUID().uuidString
+          let data = try String(contentsOf: fileURL)
+          let path = fileURL.path
+          let metadata = SearchSetup().createMetadata(
+                data: data,
+                path: fileURL.path,
+                providerType: .file
+            )
+
+            let item = SearchableItem(
+              id: id,
+              data: data,
+              path: path,
+              metadata: metadata
+            )
+
+            searchableItems.append(item)
+        }
+
+        return searchableItems
+    }
+}
+
+final class RealtimeDatabaseProvider: Provider {
+  func fetchItems(for options: SearchOptions) async throws -> [SearchableItem] {
+      var searchableItems: [SearchableItem] = []
+      let db = Database.database().reference()
+
+    guard let searchPaths = options.searchPaths else {
+      throw SearchError.searchPathUnavailable
+    }
+
+      for path in searchPaths {
+          let fetchedItems: [SearchableItem] = try await withCheckedThrowingContinuation { continuation in
+              db.child(path).observeSingleEvent(of: .value, with: { snapshot in
+                  guard let value = snapshot.value as? [String: Any] else {
+                    continuation.resume(throwing: SearchError.invalidSnapshotFormat)
+                      return
+                  }
+
+                  var localItems: [SearchableItem] = []
+
+                for (key, value) in value {
+                    if let dict = value as? [String: Any] {
+                        let id = key
+                        let path = "\(path)/\(key)"
+                        let data = SearchSetup().extractText(from: dict)
+
+                        let metadata = SearchSetup().createMetadata(
+                            data: data,
+                            path: path,
+                            providerType: .database
+                        )
+
+                        let item = SearchableItem(
+                            id: id,
+                            data: data,
+                            path: path,
+                            metadata: metadata
+                        )
+
+                        localItems.append(item)
+                    }
+                }
+
+                continuation.resume(returning: localItems)
+              })
+          }
+
+        searchableItems.append(contentsOf: fetchedItems)
+      }
+
+      return searchableItems
+  }
+}
+
 
 /// Algorithm for exact string matching
 struct ExactMatchAlgorithm: SearchAlgorithm {
   let provider: Provider
 
-    func search(term: String, type _: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
+    func search(term: String, type: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
         let searchTerm = options.caseSensitive ? term : term.lowercased()
         let items = try await provider.fetchItems(for: options)
 
@@ -161,13 +317,13 @@ struct ExactMatchAlgorithm: SearchAlgorithm {
 
 
       for item in items {
-          let title = options.caseSensitive ? item.title : item.title.lowercased()
+          let searchableData = options.caseSensitive ? item.data : item.data.lowercased()
 
-          if title.contains(searchTerm) {
-              let score = title == searchTerm ? 1.0 : 0.7
+          if searchableData.contains(searchTerm) {
+              let score = searchableData == searchTerm ? 1.0 : 0.7
 
               results.append(SearchMind.SearchResult(
-                  matchType: .file,
+                  matchType: type,
                   path: item.path,
                   relevanceScore: score,
                   matchedTerms: [term]
@@ -183,7 +339,7 @@ struct ExactMatchAlgorithm: SearchAlgorithm {
 /// Algorithm for fuzzy string matching using Swift Algorithms
 struct FuzzyMatchAlgorithm: SearchAlgorithm {
   let provider: Provider
-    func search(term: String, type _: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
+    func search(term: String, type: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
         let searchTerm = options.caseSensitive ? term : term.lowercased()
         let items = try await provider.fetchItems(for: options)
 
@@ -191,21 +347,21 @@ struct FuzzyMatchAlgorithm: SearchAlgorithm {
         var results: [SearchMind.SearchResult] = []
 
         for item in items {
-            let title = options.caseSensitive ? item.title : item.title.lowercased()
+            let searchableData = options.caseSensitive ? item.data : item.data.lowercased()
 
             // Using Swift Algorithms to calculate Levenshtein distance
-            let distance = calculateLevenshteinDistance(from: searchTerm, to: title)
+            let distance = calculateLevenshteinDistance(from: searchTerm, to: searchableData)
 
             // Calculate normalized relevance score (0 to 1)
             // Lower distance = higher relevance
-            let maxLength = max(searchTerm.count, title.count)
+            let maxLength = max(searchTerm.count, searchableData.count)
             let normalizedDistance = maxLength > 0 ? Double(distance) / Double(maxLength) : 1.0
             let relevanceScore = 1.0 - normalizedDistance
 
             // Only include results above a certain relevance threshold
             if relevanceScore > 0.3 {
                 results.append(SearchMind.SearchResult(
-                    matchType: .file,
+                    matchType: type,
                     path: item.path,
                     relevanceScore: relevanceScore,
                     matchedTerms: [term]
@@ -255,7 +411,7 @@ struct FuzzyMatchAlgorithm: SearchAlgorithm {
 struct PatternMatchAlgorithm: SearchAlgorithm {
     let provider: Provider
 
-    func search(term: String, type _: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
+    func search(term: String, type: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
         let searchTerm = options.caseSensitive ? term : term.lowercased()
         let items = try await provider.fetchItems(for: options)
 
@@ -263,32 +419,25 @@ struct PatternMatchAlgorithm: SearchAlgorithm {
 
         // Search through file contents (limited to text files)
         for item in items {
-            do {
-                let url = URL(fileURLWithPath: item.path)
-                let itemContents = try String(contentsOf: url)
-                let compareContents = options.caseSensitive ? itemContents : itemContents.lowercased()
+          let searchableData = options.caseSensitive ? item.data : item.data.lowercased()
 
-                // Simple content search to find matches
-                if compareContents.contains(searchTerm) {
-                    // Extract context around the match
-                    let context = extractContext(from: compareContents, around: searchTerm)
+          // Simple content search to find matches
+          if searchableData.contains(searchTerm) {
+              // Extract context around the match
+              let context = extractContext(from: searchableData, around: searchTerm)
 
-                    // Count matches to influence relevance score
-                    let matchCount = compareContents.components(separatedBy: searchTerm).count - 1
-                    let relevanceScore = min(Double(matchCount) * 0.1 + 0.5, 1.0)
+              // Count matches to influence relevance score
+              let matchCount = searchableData.components(separatedBy: searchTerm).count - 1
+              let relevanceScore = min(Double(matchCount) * 0.1 + 0.5, 1.0)
 
-                    results.append(SearchMind.SearchResult(
-                        matchType: .fileContents,
-                        path: item.path,
-                        relevanceScore: relevanceScore,
-                        matchedTerms: [term],
-                        context: context
-                    ))
-                }
-            } catch {
-                // Skip files that can't be read as text
-                continue
-            }
+              results.append(SearchMind.SearchResult(
+                  matchType: type,
+                  path: item.path,
+                  relevanceScore: relevanceScore,
+                  matchedTerms: [term],
+                  context: context
+              ))
+          }
         }
 
         // Sort by relevance score
@@ -323,25 +472,26 @@ struct PatternMatchAlgorithm: SearchAlgorithm {
 /// Algorithm for semantic search with AI
 struct GPTSemanticSearchAlgorithm: SearchAlgorithm {
   let provider: Provider
-    func search(term: String, type _: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
+    func search(term: String, type: SearchType, options: SearchOptions) async throws -> [SearchMind.SearchResult] {
         let searchTerm = options.caseSensitive ? term : term.lowercased()
         let items = try await provider.fetchItems(for: options)
         guard let apiKey = options.apiKey else {
             throw SearchError.missingKey
         }
-        let termEmbedding = try await embed(text: searchTerm, apiKey: apiKey)
+        let termEmbedding = try await embed(data: searchTerm, apiKey: apiKey)
 
         var results: [SearchMind.SearchResult] = []
 
         for item in items {
-            let url = URL(fileURLWithPath: item.path)
-            let content = try String(contentsOf: url)
-          let fileEmbedding = try await embed(text: content, apiKey: apiKey)
+
+          let searchableData = options.caseSensitive ? item.data : item.data.lowercased()
+
+          let fileEmbedding = try await embed(data: searchableData, apiKey: apiKey)
 
             let similarity = cosineSimilarity(termEmbedding, fileEmbedding)
             if similarity > 0.4 {
                 results.append(SearchMind.SearchResult(
-                    matchType: .fileContents,
+                    matchType: type,
                     path: item.path,
                     relevanceScore: similarity,
                     matchedTerms: [term]
@@ -354,8 +504,8 @@ struct GPTSemanticSearchAlgorithm: SearchAlgorithm {
             .map { $0 }
     }
 
-    private func embed(text: String, apiKey: String) async throws -> [Double] {
-        let request = EmbeddingRequest(model: "text-embedding-ada-002", input: [text])
+    private func embed(data: String, apiKey: String) async throws -> [Double] {
+        let request = EmbeddingRequest(model: "text-embedding-ada-002", input: [data])
         let jsonData = try JSONEncoder().encode(request)
 
         var urlRequest = URLRequest(url: URL(string: "https://api.openai.com/v1/embeddings")!)

--- a/Sources/SearchMind/Internal/SearchError.swift
+++ b/Sources/SearchMind/Internal/SearchError.swift
@@ -22,7 +22,7 @@ import Foundation
 ///     print("Error: \(error.localizedDescription)")
 /// }
 /// ```
-public enum SearchError: Error, LocalizedError, Sendable {
+public enum SearchError: Error, LocalizedError, Sendable, Equatable {
     /// The specified search path does not exist
     ///
     /// This error occurs when a search path provided in `SearchOptions.searchPaths`
@@ -70,6 +70,25 @@ public enum SearchError: Error, LocalizedError, Sendable {
     /// The extraction of the data into the embedding model have failed
     case failedEmbeddingExtraction
 
+    /// The search path must be provided to define the scope of the search operation
+    ///
+    /// This error states that there is not search scope defined to begin the operation on
+    case searchPathUnavailable
+
+    /// An error indicating that the Firebase Realtime Database snapshot value was not in the expected `[String: Any]` dictionary format.
+    ///
+    /// This error is typically thrown when attempting to cast the snapshot's `value` property fails due to:
+    /// - The snapshot being `nil`
+    /// - The snapshot containing data of an unexpected type (e.g. an array, string, number, etc.)
+    /// - The snapshot data being malformed or not structured as a dictionary
+    case invalidSnapshotFormat
+
+    /// The operation of content extraction from the target file is facing issues
+    ///
+    /// Thie error states that the content we are trying to reach is facing
+    /// extraction issues
+    case unableToLoadContent
+
     /// Human-readable description of the error
     ///
     /// This property is part of the `LocalizedError` protocol and provides
@@ -90,6 +109,12 @@ public enum SearchError: Error, LocalizedError, Sendable {
             return "API key not found"
         case .failedEmbeddingExtraction:
             return "Failed to extract embedding from the fetched api data"
+        case .searchPathUnavailable:
+            return "Search path not defined. Can't begin the operation, missing the search scope"
+        case .invalidSnapshotFormat:
+          return "Snapshot data is not in the expected format."
+        case .unableToLoadContent:
+          return "Unable to extract content from the target file"
         }
     }
 }

--- a/Sources/SearchMind/Internal/Utility/SearchSetup.swift
+++ b/Sources/SearchMind/Internal/Utility/SearchSetup.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct SearchSetup {
+  func createMetadata(
+          data: String?,
+          path: String,
+          providerType: SearchType
+      ) -> [String: String] {
+          let url = URL(fileURLWithPath: path)
+          var metadata: [String: String] = [:]
+
+          switch providerType {
+          case .file:
+              metadata["provider"] = "file"
+              metadata["filename"] = url.lastPathComponent
+              metadata["fileExtension"] = url.pathExtension
+              metadata["directory"] = url.deletingLastPathComponent().lastPathComponent
+
+          case .fileContents:
+              metadata["provider"] = "fileContents"
+              metadata["filename"] = url.lastPathComponent
+              metadata["fileExtension"] = url.pathExtension
+              metadata["lineCount"] = data.map { "\($0.components(separatedBy: .newlines).count)" } ?? "0"
+              metadata["characterCount"] = data.map { "\($0.count)" } ?? "0"
+              metadata["preview"] = data.map { String($0.prefix(80)).replacingOccurrences(of: "\n", with: " ") } ?? ""
+
+          case .database:
+              metadata["provider"] = "database"
+              metadata["collection"] = url.deletingLastPathComponent().lastPathComponent
+              metadata["documentId"] = url.deletingPathExtension().lastPathComponent
+              metadata["preview"] = data.map { String($0.prefix(80)).replacingOccurrences(of: "\n", with: " ") } ?? ""
+          }
+
+          return metadata
+      }
+
+  /// Recursively flattens all string-like values in a dictionary to a single text blob.
+  func extractText(from dictionary: [String: Any]) -> String {
+      var collectedText: [String] = []
+
+      func flatten(_ value: Any) {
+          if let string = value as? String {
+              collectedText.append(string)
+          } else if let number = value as? NSNumber {
+              collectedText.append(number.stringValue)
+          } else if let array = value as? [Any] {
+              array.forEach(flatten)
+          } else if let dict = value as? [String: Any] {
+              for key in dict.keys.sorted() {
+                  if let value = dict[key] {
+                      flatten(value)
+                  }
+              }
+          }
+      }
+
+      flatten(dictionary)
+      return collectedText.joined(separator: "\n")
+  }
+}

--- a/Tests/SearchMindTests/.swift
+++ b/Tests/SearchMindTests/.swift
@@ -1,0 +1,70 @@
+import XCTest
+import FirebaseCore
+import FirebaseDatabase
+@testable import SearchMind
+
+final class RealtimeDatabaseProviderTests: XCTestCase {
+
+    var provider: RealtimeDatabaseProvider!
+
+    override func setUp() {
+        super.setUp()
+
+        // Firebase manual config from SPM resource bundle
+        if FirebaseApp.app() == nil {
+            let testBundle = Bundle(for: type(of: self))
+            guard let filePath = testBundle.path(forResource: "GoogleService-Info", ofType: "plist"),
+                  let options = FirebaseOptions(contentsOfFile: filePath) else {
+                fatalError("Failed to load GoogleService-Info.plist from test bundle.")
+            }
+            FirebaseApp.configure(options: options)
+        }
+        provider = RealtimeDatabaseProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        super.tearDown()
+    }
+
+    func testSearchReturnsMatchingPosts() async throws {
+        // Given
+        let testPath = "test/posts"
+        let ref = Database.database().reference(withPath: testPath)
+
+        // Clean up existing data
+        try await ref.removeValue()
+
+        let sampleData: [String: Any] = [
+            "post1": [
+                "id": "1",
+                "title": "Swift Concurrency",
+                "content": "Learn structured concurrency"
+            ],
+            "post2": [
+                "id": "2",
+                "title": "iOS Testing",
+                "content": "Unit and UI testing in Xcode"
+            ],
+            "post3": [
+                "id": "3",
+                "title": "Unrelated",
+                "content": "Nothing about the topic"
+            ]
+        ]
+
+        // Write sample data to Firebase
+        try await ref.setValue(sampleData)
+
+        let options = SearchOptions(searchPaths: [URL(string: testPath)!])
+        let query = "swift"
+
+        // When
+        let results: [SearchableItem] = try await provider.fetchItems(for: options)
+
+        // Then
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.title, "Swift Concurrency")
+        XCTAssertEqual(results.first?.id, "1")
+    }
+}

--- a/Tests/SearchMindTests/Providers/FileProviderTests.swift
+++ b/Tests/SearchMindTests/Providers/FileProviderTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import SearchMind
+
+final class FileProviderTests: XCTestCase {
+    var fileProvider: FileProvider!
+    var tempDirectory: String!
+
+    override func setUpWithError() throws {
+        fileProvider = FileProvider()
+        tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+      try FileManager.default.createDirectory(at: URL(fileURLWithPath: tempDirectory), withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+      try? FileManager.default.removeItem(at: URL(fileURLWithPath: tempDirectory))
+    }
+
+    func createFile(named name: String, withExtension ext: String = "txt") throws -> URL {
+        let fileURL = URL(fileURLWithPath: tempDirectory).appendingPathComponent("\(name).\(ext)")
+        try "Test Content".write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+
+    func test_fetchItems_returnsAllFilesInDirectory() async throws {
+        _ = try createFile(named: "file1")
+        _ = try createFile(named: "file2")
+
+        let options = SearchOptions(searchPaths: [tempDirectory], fileExtensions: nil)
+
+        let items = try await fileProvider.fetchItems(for: options)
+
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.allSatisfy { $0.data.hasSuffix(".txt") })
+    }
+
+    func test_fetchItems_filtersByFileExtension() async throws {
+        _ = try createFile(named: "notes", withExtension: "md")
+        _ = try createFile(named: "code", withExtension: "swift")
+
+        let options = SearchOptions(searchPaths: [tempDirectory], fileExtensions: ["swift"])
+
+        let items = try await fileProvider.fetchItems(for: options)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.data, "code.swift")
+    }
+
+  func test_fetchItems_shouldThrowError_forInvalidPath() async throws {
+      let provider = FileProvider()
+      let invalidPath = "/invalid/path"
+      let options = SearchOptions(searchPaths: [invalidPath])
+
+      do {
+          _ = try await provider.fetchItems(for: options)
+          XCTFail("Expected error not thrown")
+      } catch let error as SearchError {
+          XCTAssertEqual(error, .invalidSearchPath(invalidPath))
+      } catch {
+          XCTFail("Unexpected error: \(error)")
+      }
+  }
+}
+

--- a/Tests/SearchMindTests/Providers/RealtimeDatabaseProviderTests.swift
+++ b/Tests/SearchMindTests/Providers/RealtimeDatabaseProviderTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import FirebaseCore
+import FirebaseDatabase
+@testable import SearchMind
+
+final class RealtimeDatabaseProviderTests: XCTestCase {
+
+    var provider: RealtimeDatabaseProvider!
+
+    override func setUp() {
+        super.setUp()
+
+        if FirebaseApp.app() == nil {
+            guard let plistPath = Bundle.module.path(forResource: "GoogleService-Info", ofType: "plist") else {
+                XCTFail("GoogleService-Info.plist not found in Bundle.module. Make sure it's marked as a resource in Package.swift.")
+                return
+            }
+
+            guard let options = FirebaseOptions(contentsOfFile: plistPath) else {
+                XCTFail("Unable to create FirebaseOptions from GoogleService-Info.plist")
+                return
+            }
+
+            FirebaseApp.configure(options: options)
+        }
+
+        provider = RealtimeDatabaseProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        super.tearDown()
+    }
+
+  func testSearchReturnsMatchingPosts() async throws {
+      let testPath = "test/posts"
+      let ref = Database.database().reference(withPath: testPath)
+
+      try await ref.removeValue()
+
+      let sampleData: [String: Any] = [
+          "post1": ["id": "1", "title": "Swift Concurrency", "content": "Learn structured concurrency"],
+          "post2": ["id": "2", "title": "iOS Testing", "content": "Unit and UI testing in Xcode"],
+          "post3": ["id": "3", "title": "Unrelated", "content": "Nothing about the topic"]
+      ]
+
+      try await ref.setValue(sampleData)
+
+      let options = SearchOptions(searchPaths: [testPath])
+
+    let results: [SearchableItem] = try await provider.fetchItems(for: options).sorted { $0.id < $1.id }
+
+
+      XCTAssertEqual(results.count, 3)
+      XCTAssertEqual(results.first?.data, "Learn structured concurrency\n1\nSwift Concurrency")
+      XCTAssertEqual(results.first?.id, "post1")
+  }
+}

--- a/Tests/SearchMindTests/Resources/GoogleService-Info.plist
+++ b/Tests/SearchMindTests/Resources/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAjChnaAEzyPl-F_hPzm7RxX5o6YhuuYZ0</string>
+	<key>GCM_SENDER_ID</key>
+	<string>992527242511</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.ashkan-ebtekari.searchmind</string>
+	<key>PROJECT_ID</key>
+	<string>searchmind-9d27a</string>
+	<key>STORAGE_BUCKET</key>
+	<string>searchmind-9d27a.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:992527242511:ios:778600b454199f1f539a7a</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

This PR introduces full support for `SearchType.database`, enabling **SearchMind** to perform powerful search operations over `Firebase Realtime Database`. It marks a major milestone by expanding the engine beyond _file-based_ sources into _cloud-hosted_, structured data.

In addition to this new capability, the PR delivers **significant** architectural improvements:
- Search logic is now **fully decoupled** from _data source_ and _structure_, making all search algorithms work interchangeably across `.file`, `.fileContents`, and `.database`.
- The codebase introduces **modular providers** and clean abstractions, **simplifying future expansions** to other data systems (e.g., Firestore, CoreData, REST APIs).
- A robust, automated test matrix ensures correctness across **all combinations** of `search types` and `algorithms`.

These changes not only improve **flexibility** and **scalability** but also prepare the foundation for _multi-source_, _production grade semantic_ and _hybrid search applications_.

## Changes
- Added `SearchType.database` support
   - Enables searching within `Firebase Realtime Database` nodes _just like files_.
   - This expands the system from **local only search** to **cloud-based sources**, making the engine usable across _distributed_ or _collaborative environments_.
   - Allows developers to _search structured data_ without writing new data adapters manually.
- Introduced `FileContentsProvider` for `.fileContents` search
   - Previously, some search algorithms were limited to `.file` and **file names**. This new provider allows full text search inside files which supports `.fileContents`.
   - Useful for searching documents, code, or notes. Not just file names.
   - This enhances the utility of the search engine in real world workspaces where data exists inside files.
- Added `RealtimeDatabaseProvider` for Firebase
   - Allows _automatic fetching_ and _flattening_ of **Firebase JSON** tree structures into `SearchableItem` models.
   - Then the search engine will do search operations based on the **selected search algorithm** on these `SearchableItem` models
   - Users can point the engine to **any Firebase path**, and the **provider** handles _traversal_ and _decoding_.
   - Greatly reduces boilerplate for integrating `Firebase` with search.
- Simplified `SearchableItem` model
   - Removed title and content, replaced with a unified data string, which is used as the single searchable data for search operations
   - Eliminates ambiguity about which fields are searchable.
   - Makes indexing, comparison, and embedding generation uniform across all sources and providers.
- Made the `FirebaseRealtimeProvider` data fetching generic
   - Updated to detect structure dynamically by making the fetching process **generic**
   - The fetching process will be done despite the _user database_ data structure
   - The **provider** recognizes the target path key's and child's
- Centralized and modularized all search algorithms
   - Each algorithm (.exact, .fuzzy, .semantic, .patternMatch) is now generic and follows a single responsibility, which is the searching operation
   - This separation of concerns makes it easy to add **new algorithms** in the future without touching unrelated code.
   - Also improves testability, reusability, and clarity of search logic.
- Improved metadata generation using `createMetadata()`
   - Metadata now includes meaningful context such as source type, path, and origin.
   - Generated consistently for each `SearchableItem`, improving traceability and debugging.
   - Provider specific behavior ensures relevant tagging (e.g., .database vs .file metadata).
- Enhanced error handling
   - `SearchError.invalidSnapshotFormat`: Catches Firebase nodes that don’t conform to expected formats.
   - `SearchError.unableToLoadContent`: Added to report when file reading fails.
   - These explicit errors make **failures** _easier to diagnose_ and _prevent_ silent crashes or broken results.
- Added full **cross-type** test coverage
   - Each **algorithm** is tested against _all supported source types_: `.file`, `.fileContents`, and `.database`.
   - Guarantees that **combinations** behave consistently and nothing breaks in _edge cases_.
   - Also verifies correct _path resolution_ and _result matching_.
- Created the `extractText` utility
   - Ensures clean, normalized strings (e.g., removing GPT tags) for accurate search input.
   - Keeps core logic clean by offloading these responsibilities into utility layers.
- Improved **test setup** with file and database fixtures
   - Local **file setup** uses _temporary directories_ and sample files (e.g., sample.txt, document.doc).
   - Firebase _test setup_ dynamically writes **structured data** to a test path and resets it between runs.
   - This ensures a clean slate every time, reducing flakiness and increasing test reliability.

## Testing
- Added exhaustive tests covering every algorithm against every data provider:
   - `File names`
   - `File contents`
   - `Firebase Realtime Database`
- Used XCTest with dynamic enums to **test all combinations** of _search algorithm_ and _source_.
- Firebase is configured via a test specific `GoogleService-Info.plist` included in the module bundle.
- Verified fuzzy, semantic, pattern matching and exact against all data sources using real fixtures.

## Related Issues

Closes #6

## Next Steps
- Getting the `database path` from the user and **decoupling** the _firebase realtime database configuration_
- Adding support for new `database types`, including **CoreData**, **SQL databases** and etc, by creating more **providers**
- Adding features which leverages the fetched **metadata** for each `SearchableItem`, giving users a richer experience for using the returned matched data
- Improving **documentation** of the whole project
- Refactoring reused code by having **the rule of three** in mind and **creating more helper functions** in the _Utility_ to decrease the _complexity of the search engine_.
- Creating the `FileContentsProviderTests`